### PR TITLE
Fix production AI chat backend URL

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -19,7 +19,7 @@ build/
 Set these in the hosting provider:
 
 ```env
-REACT_APP_API_URL=https://digital-logics-studio-backend.vercel.app/api
+REACT_APP_API_URL=https://digital-logics-studio-backend-three.vercel.app/api
 REACT_APP_SITE_URL=https://circuits.quantumlogicslimited.com
 REACT_APP_GA_MEASUREMENT_ID=
 REACT_APP_GOOGLE_SITE_VERIFICATION=

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,26 +1,30 @@
 const LOCAL_API_URL = "http://localhost:5000/api";
 const PRODUCTION_API_URL =
-  "https://digital-logics-studio-backend-three.vercel.app/api"; // production
-const DEPRECATED_API_URL =
-  "https://digital-logics-studio-backend.vercel.app/api";  // production
+  "https://digital-logics-studio-backend-three.vercel.app/api";
+// Old Vercel deploy had this URL baked in / set as env — it has no Groq keys.
+const LEGACY_PRODUCTION_API_URL =
+  "https://digital-logics-studio-backend.vercel.app/api";
+
+function normalizeUrl(url) {
+  return url.trim().replace(/\/+$/, "");
+}
 
 export function resolveApiBaseUrl() {
   const configured = process.env.REACT_APP_API_URL?.trim();
-  let url = configured
-    ? configured.replace(/\/+$/, "")
-    : process.env.NODE_ENV === "production"
-      ? PRODUCTION_API_URL
-      : LOCAL_API_URL;
-
-  if (url === DEPRECATED_API_URL) {
-    url = PRODUCTION_API_URL;
+  if (configured) {
+    const normalized = normalizeUrl(configured);
+    if (normalized === normalizeUrl(LEGACY_PRODUCTION_API_URL)) {
+      return normalizeUrl(PRODUCTION_API_URL);
+    }
+    return normalized;
   }
-
-  return url;
+  return process.env.NODE_ENV === "production" ? normalizeUrl(PRODUCTION_API_URL) : LOCAL_API_URL;
 }
 
 export function resolveAiBaseUrl() {
   const configuredAi = process.env.REACT_APP_AI_URL?.trim();
-  if (configuredAi) return configuredAi.replace(/\/+$/, "");
+  if (configuredAi) {
+    return configuredAi.replace(/\/+$/, "");
+  }
   return `${resolveApiBaseUrl()}/ai`;
 }

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,0 +1,26 @@
+const LOCAL_API_URL = "http://localhost:5000/api";
+const PRODUCTION_API_URL =
+  "https://digital-logics-studio-backend-three.vercel.app/api"; // production
+const DEPRECATED_API_URL =
+  "https://digital-logics-studio-backend.vercel.app/api";  // production
+
+export function resolveApiBaseUrl() {
+  const configured = process.env.REACT_APP_API_URL?.trim();
+  let url = configured
+    ? configured.replace(/\/+$/, "")
+    : process.env.NODE_ENV === "production"
+      ? PRODUCTION_API_URL
+      : LOCAL_API_URL;
+
+  if (url === DEPRECATED_API_URL) {
+    url = PRODUCTION_API_URL;
+  }
+
+  return url;
+}
+
+export function resolveAiBaseUrl() {
+  const configuredAi = process.env.REACT_APP_AI_URL?.trim();
+  if (configuredAi) return configuredAi.replace(/\/+$/, "");
+  return `${resolveApiBaseUrl()}/ai`;
+}

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -1,18 +1,5 @@
 import axios from "axios";
-
-const LOCAL_API_URL = "http://localhost:5000/api";
-
-function resolveApiBaseUrl() {
-  const configured = process.env.REACT_APP_API_URL?.trim();
-  if (configured) return configured.replace(/\/+$/, "");
-  return LOCAL_API_URL;
-}
-
-function resolveAiBaseUrl() {
-  const configuredAi = process.env.REACT_APP_AI_URL?.trim();
-  if (configuredAi) return configuredAi.replace(/\/+$/, "");
-  return `${resolveApiBaseUrl()}/ai`;
-}
+import { resolveAiBaseUrl } from "../config/apiConfig";
 
 const aiClient = axios.create({
   baseURL: resolveAiBaseUrl(),

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,31 +1,17 @@
 import axios from "axios";
-
-const LOCAL_API_URL = "http://localhost:5000/api";
-const PRODUCTION_API_URL = "https://digital-logics-studio-backend.vercel.app/api";
-
-function resolveApiBaseUrl() {
-  const configuredApiUrl = process.env.REACT_APP_API_URL?.trim();
-
-  if (configuredApiUrl) {
-    return configuredApiUrl.replace(/\/+$/, "");
-  }
-
-  return process.env.NODE_ENV === "production" ? PRODUCTION_API_URL : LOCAL_API_URL;
-}
+import { resolveApiBaseUrl } from "../config/apiConfig";
 
 const apiClient = axios.create({
   baseURL: resolveApiBaseUrl(),
-  withCredentials: true, // Required to send/receive the httpOnly auth cookie
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },
 });
 
-// Global response interceptor: surface API error messages cleanly
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    // Attach backend error message to the thrown error so callers can use it
     if (error.response?.data?.message) {
       error.message = error.response.data.message;
     }


### PR DESCRIPTION
## Summary
- Route production API calls to backend-three (has Groq/Pinecone keys)
- Auto-migrate off deprecated old backend URL

## Test plan
- [ ] Redeploy frontend after merge
- [ ] DLS Mentor chat works on circuits.quantumlogicslimited.com

Made with [Cursor](https://cursor.com)