### PR TITLE
Fix DLD/COAL theory navigation and diagram styling

### DIFF
--- a/src/features/coal/components/CoalDiagrams.jsx
+++ b/src/features/coal/components/CoalDiagrams.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./CoalTopicCard.css";
 
 export function VonNeumannDiagram() {
   return (

--- a/src/features/dld-theory/arithmetic-hdl/components/AFHDLLayout.jsx
+++ b/src/features/dld-theory/arithmetic-hdl/components/AFHDLLayout.jsx
@@ -9,6 +9,7 @@ const AFHDLLayout = ({ title, subtitle, intro, highlights = [], children }) => (
     intro={intro}
     highlights={highlights}
     pages={afhdlPages}
+    overviewPath={afhdlPages[0]?.path}
     topicLabel="Arithmetic & HDLs"
     sidebarTitle="Arithmetic Toolkit"
     sidebarCopy="Learn one operation at a time, then connect ideas to hardware design."
@@ -18,6 +19,8 @@ const AFHDLLayout = ({ title, subtitle, intro, highlights = [], children }) => (
       topic: AFHDL_TOPIC,
       pathToSubtopicId: AFHDL_PATH_TO_SUBTOPIC_ID,
     }}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/boolean-algebra/BALayout.jsx
+++ b/src/features/dld-theory/boolean-algebra/BALayout.jsx
@@ -1,7 +1,16 @@
 import React from "react";
 import TopicLayout from "../../../shared/components/topics/TopicLayout";
+import { dldCourseParts } from "../../../shared/data/dldCourseOutline";
 import "./BALayout.css";
 import { baPages, BA_TOPIC, BA_PATH_TO_SUBTOPIC_ID } from "./components/baConfig";
+
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "boolean-algebra");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const BALayout = ({ title, subtitle, intro, highlights = [], children }) => (
   <TopicLayout
@@ -21,6 +30,10 @@ const BALayout = ({ title, subtitle, intro, highlights = [], children }) => (
       topic: BA_TOPIC,
       pathToSubtopicId: BA_PATH_TO_SUBTOPIC_ID,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
+++ b/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
@@ -1,11 +1,19 @@
 import React from "react";
 import TopicLayout from "../../../shared/components/topics/TopicLayout";
+import { dldCourseParts } from "../../../shared/data/dldCourseOutline";
 import {
   combinationalPages,
   COMBINATIONAL_TOPIC,
   COMBINATIONAL_PATH_TO_SUBTOPIC_ID,
 } from "./combinationalConfig";
 
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "combinational-circuits");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const CombinationalLayout = ({
   title,
@@ -29,6 +37,10 @@ const CombinationalLayout = ({
       topic: COMBINATIONAL_TOPIC,
       pathToSubtopicId: COMBINATIONAL_PATH_TO_SUBTOPIC_ID,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/number-systems/components/NSLayout.jsx
+++ b/src/features/dld-theory/number-systems/components/NSLayout.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import TopicLayout from "../../../../shared/components/topics/TopicLayout";
+import { dldCourseParts } from "../../../../shared/data/dldCourseOutline";
 import "./NSLayout.css";
 import {
   nsPages,
@@ -8,6 +9,14 @@ import {
   NS_TOPIC,
   NS_DEFAULT_HIGHLIGHTS,
 } from "./nsConfig";
+
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "number-systems");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const NSLayout = ({ title, subtitle, intro, highlights = [], children }) => (
   <TopicLayout
@@ -29,6 +38,10 @@ const NSLayout = ({ title, subtitle, intro, highlights = [], children }) => (
       pathToSubtopicId: NS_PATH_TO_SUBTOPIC_ID,
       subtopicAliases: NS_LEGACY_SUBTOPIC_ALIASES,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/registers-transfers/RegLayout.jsx
+++ b/src/features/dld-theory/registers-transfers/RegLayout.jsx
@@ -1,8 +1,16 @@
 import React from "react";
 import TopicLayout from "../../../shared/components/topics/TopicLayout";
+import { dldCourseParts } from "../../../shared/data/dldCourseOutline";
 import "./RegStyles.css";
 import { regPages, REG_TOPIC, REG_PATH_TO_SUBTOPIC_ID } from "./regConfig";
 
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "registers-and-register-transfers");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const RegLayout = ({ children, title, subtitle }) => (
   <TopicLayout
@@ -19,6 +27,10 @@ const RegLayout = ({ children, title, subtitle }) => (
       topic: REG_TOPIC,
       pathToSubtopicId: REG_PATH_TO_SUBTOPIC_ID,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
+++ b/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
@@ -1,8 +1,16 @@
 import React from "react";
 import TopicLayout from "../../../shared/components/topics/TopicLayout";
+import { dldCourseParts } from "../../../shared/data/dldCourseOutline";
 import "./SeqLayout.css";
 import { seqPages, SEQ_TOPIC, SEQ_PATH_TO_SUBTOPIC_ID } from "./seqConfig";
 
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "sequential-circuits");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const SeqLayout = ({ children, title, subtitle }) => (
   <TopicLayout
@@ -19,6 +27,10 @@ const SeqLayout = ({ children, title, subtitle }) => (
       topic: SEQ_TOPIC,
       pathToSubtopicId: SEQ_PATH_TO_SUBTOPIC_ID,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/shared/components/topics/PremiumLearningShell.jsx
+++ b/src/shared/components/topics/PremiumLearningShell.jsx
@@ -92,8 +92,10 @@ const PremiumLearningShell = ({
   progressVerb = "complete",
   tracking,
   rootClassName = "",
-  sidebarFooterLink = "/",
+   sidebarFooterLink = "/",
   sidebarFooterLabel = "← Back to All Topics",
+  nextPartPath = null,      // ← add
+  nextPartLabel = null,
 }) => {
   const location = useLocation();
   const { theme, toggle: toggleTheme } = useTheme();
@@ -113,11 +115,11 @@ const PremiumLearningShell = ({
     : currentIndex > 0
       ? chapterPages[currentIndex - 1]
       : null;
-  const next = isOverview
-    ? chapterPages[0] || null
-    : currentIndex >= 0 && currentIndex < chapterPages.length - 1
-      ? chapterPages[currentIndex + 1]
-      : null;
+ const next = isOverview
+  ? (chapterPages[0]?.path === currentPath ? chapterPages[1] : chapterPages[0]) || null
+  : currentIndex >= 0 && currentIndex < chapterPages.length - 1
+    ? chapterPages[currentIndex + 1]
+    : null;
 
   const pathToSubtopicId = tracking?.pathToSubtopicId || {};
   const subtopicAliases = tracking?.subtopicAliases || EMPTY_ALIASES;
@@ -210,6 +212,35 @@ const PremiumLearningShell = ({
   );
   const progressDash = progress * 0.879;
   const isRead = subtopicId ? completedSubtopics.includes(subtopicId) : false;
+
+  // Auto-mark as read once the user has scrolled through ~90% of the
+// page. Only fires once per page visit, and only if not already read
+// — scrolling back up/down again after that does nothing further.
+const autoMarkedRef = useRef(false);
+
+useEffect(() => {
+  autoMarkedRef.current = false;
+}, [currentPath]);
+
+useEffect(() => {
+  if (!trackedTopic || !subtopicId || !catalog) return;
+
+  const checkScrollProgress = () => {
+    if (autoMarkedRef.current || isRead) return;
+
+    const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (scrollableHeight <= 0) return;
+
+    const scrollPercent = (window.scrollY / scrollableHeight) * 100;
+    if (scrollPercent >= 90) {
+      autoMarkedRef.current = true;
+      toggleCompletion();
+    }
+  };
+
+  window.addEventListener("scroll", checkScrollProgress, { passive: true });
+  return () => window.removeEventListener("scroll", checkScrollProgress);
+}, [trackedTopic, subtopicId, catalog, isRead, toggleCompletion]);
 
   const pageDone = (pageIndex, page) => {
     if (isSidebarItemDone) return isSidebarItemDone(page, completedSubtopics);
@@ -378,11 +409,17 @@ const PremiumLearningShell = ({
 
         <main className="afhdl-main">
           <nav className="afhdl-breadcrumb" aria-label="Breadcrumb">
-            <Link to="/" className="afhdl-bc-link">
-              Home
-            </Link>
+            <Link to={sidebarFooterLink} className="afhdl-bc-link">
+             Home
+             </Link>
             <span className="afhdl-bc-sep">›</span>
-            <span className="afhdl-bc-mid">{topicLabel}</span>
+           {overviewPath ? (
+           <Link to={overviewPath} className="afhdl-bc-link afhdl-bc-mid">
+            {topicLabel}
+          </Link>
+           ) : (
+           <span className="afhdl-bc-mid">{topicLabel}</span>
+           )}
             <span className="afhdl-bc-sep">›</span>
             <span className="afhdl-bc-current">{title}</span>
           </nav>
@@ -497,17 +534,29 @@ const PremiumLearningShell = ({
                     </svg>
                   </span>
                 </NavLink>
-              ) : (
-                <Link to="/" className="afhdl-footer-link afhdl-footer-link-next">
-                  <span>
-                    <span className="afhdl-footer-label">All done!</span>
-                    <span className="afhdl-footer-title">Return to Home</span>
-                  </span>
-                  <span className="afhdl-footer-arrow afhdl-footer-arrow-next">
-                    <Home size={16} aria-hidden="true" />
-                  </span>
-                </Link>
-              )}
+              ) : nextPartPath ? (
+  <Link to={nextPartPath} className="afhdl-footer-link afhdl-footer-link-next">
+    <span>
+      <span className="afhdl-footer-label">Part complete!</span>
+      <span className="afhdl-footer-title">Continue to {nextPartLabel}</span>
+    </span>
+    <span className="afhdl-footer-arrow afhdl-footer-arrow-next">
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+        <path d="M7 5l5 5-5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  </Link>
+) : (
+  <Link to="/" className="afhdl-footer-link afhdl-footer-link-next">
+    <span>
+      <span className="afhdl-footer-label">All done!</span>
+      <span className="afhdl-footer-title">Return to Home</span>
+    </span>
+    <span className="afhdl-footer-arrow afhdl-footer-arrow-next">
+      <Home size={16} aria-hidden="true" />
+    </span>
+  </Link>
+)}
             </div>
           </footer>
         </main>

--- a/src/shared/components/topics/TopicLayout.jsx
+++ b/src/shared/components/topics/TopicLayout.jsx
@@ -20,6 +20,8 @@ const TopicLayout = ({
   rootClassName = "topic-layout",
   sidebarFooterLink = "/",
   sidebarFooterLabel = "← Back to All Topics",
+  nextPartPath = null,
+  nextPartLabel = null,
   children,
 }) => (
   <PremiumLearningShell
@@ -41,6 +43,8 @@ const TopicLayout = ({
     sidebarFooterLink={sidebarFooterLink}
     sidebarFooterLabel={sidebarFooterLabel}
     tracking={tracking}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
   >
     {children}
   </PremiumLearningShell>

--- a/src/shared/layouts/AdvancedLogicLayout.jsx
+++ b/src/shared/layouts/AdvancedLogicLayout.jsx
@@ -1,10 +1,19 @@
 import React from "react";
 import TopicLayout from "../components/topics/TopicLayout";
+import { dldCourseParts } from "../data/dldCourseOutline";
 import {
   advancedLogicPages,
   ADVANCED_LOGIC_TOPIC,
   ADVANCED_LOGIC_PATH_TO_SUBTOPIC_ID,
 } from "../../features/dld-theory/logic-gates/advancedLogicConfig";
+
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "advanced-logic");
+const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < dldCourseParts.length - 1
+    ? dldCourseParts[currentPartIndex + 1]
+    : null;
+const nextPartPath = nextPart?.modules?.[0]?.path || null;
+const nextPartLabel = nextPart?.title || null;
 
 const AdvancedLogicLayout = ({
   title,
@@ -28,6 +37,10 @@ const AdvancedLogicLayout = ({
       topic: ADVANCED_LOGIC_TOPIC,
       pathToSubtopicId: ADVANCED_LOGIC_PATH_TO_SUBTOPIC_ID,
     }}
+    nextPartPath={nextPartPath}
+    nextPartLabel={nextPartLabel}
+    sidebarFooterLink="/resources/dld"
+    sidebarFooterLabel="← DLD home"
   >
     {children}
   </TopicLayout>

--- a/src/shared/layouts/TheoryLayout.jsx
+++ b/src/shared/layouts/TheoryLayout.jsx
@@ -24,6 +24,15 @@ export default function TheoryLayout({ track, children, title, subtitle, intro, 
   const { utils, courseParts } = track;
 
   const currentPart = utils.getPartForPath(pathname) || courseParts[0];
+  const currentPartIndex = courseParts.findIndex((p) => p.id === currentPart.id);
+  const nextPart =
+  currentPartIndex >= 0 && currentPartIndex < courseParts.length - 1
+    ? courseParts[currentPartIndex + 1]
+    : null;
+      const nextPartPath = nextPart?.modules?.[0]
+    ? utils.getTopicPath(nextPart.modules[0].slug)
+    : null;
+      const nextPartLabel = nextPart?.title || null;
 
   const currentPartPages = currentPart.modules.map((module) => ({
     path: utils.getTopicPath(module.slug),
@@ -64,6 +73,8 @@ export default function TheoryLayout({ track, children, title, subtitle, intro, 
       sidebarFooterLink={track.homePath}
       sidebarFooterLabel={`← ${track.id === "coal" ? "COAL" : "DLD"} home`}
       tracking={{ topic, pathToSubtopicId: utils.PATH_TO_SUBTOPIC_ID }}
+      nextPartPath={nextPartPath}
+      nextPartLabel={nextPartLabel}
     >
       {children}
     </TopicLayout>

--- a/src/shared/layouts/tracks.js
+++ b/src/shared/layouts/tracks.js
@@ -80,7 +80,7 @@ export const TRACKS = {
     parentProgressTopicId: "coal-theory",
     // COAL's hero chapter-dots span the whole course — matches its
     // existing (pre-unification) behavior.
-    pagesScope: "all",
+    pagesScope: "part",
     homeDescription:
       "A structured path from computer fundamentals to assembly and processor architecture — theory and hands-on practice in one place.",
     quickLinks: [


### PR DESCRIPTION
- Auto-mark topic as read at 90% scroll (PremiumLearningShell)
- Fix breadcrumb middle link (was non-clickable) across all 7 DLD parts
- Fix breadcrumb Home link to return to course hub instead of site root
- Fix stuck 'Next' button on part overview and first-topic pages
- Add 'Continue to next part' navigation at end of each DLD part
- Fix sidebar 'Back to All Topics' to link to course hub, not site home
- Scope COAL chapter-dots to current part instead of whole course
- Fix ia32-architecture (and other COAL) diagrams rendering as solid black boxes due to missing CSS import in CoalDiagrams.jsx

## 📌 Summary: Fixes 5 reported bugs across DLD and COAL theory pages: non-functional breadcrumb navigation, "All done" screen not progressing to the next part, COAL progress dots showing course-wide instead of per-part, missing diagram styling on ia32-architecture (and other COAL pages), and adds auto-mark-as-read at 90% scroll.
Related Issue: (link to whatever tracking item exists for these 5 tasks, or note it was assigned verbally)
Changes Made:
Auto-marks a topic as read once scrolled to ~90% (in addition to the existing manual button)
Made the breadcrumb's middle link clickable across all 7 DLD parts (Boolean Algebra, Number Systems, Combinational Circuits, Sequential Circuits, Registers & Transfers, Advanced Logic, Arithmetic & HDLs), each linking to that part's first topic
Fixed breadcrumb "Home" and sidebar "Back to All Topics" to route back to the course hub (/resources/dld or /resources/coal) rather than the site root
Fixed a bug where "Next" was stuck on the part-overview and first-topic pages (self-referential link)
Added "Continue to [Next Part]" navigation when a part is finished, replacing the old universal "Return to Home" (still falls back to Home on the last part)
Scoped COAL's hero chapter-dots to the current part only, matching DLD's existing behavior (pagesScope)
Fixed COAL diagrams (e.g. ia32-architecture) rendering as solid black SVG boxes due to a missing CSS import in CoalDiagrams.jsx
Testing: Manually verified each fix across both light/dark theme where applicable, on Boolean Algebra, Number Systems, Combinational Circuits, Sequential Circuits, Registers & Transfers, Advanced Logic, Arithmetic & HDLs, and COAL topic pages (localhost:3000).
Reviewer Notes: The breadcrumb/sidebar "Home" routing fix lives in the shared PremiumLearningShell.jsx, so it also changes COAL's breadcrumb Home behavior (now goes to /resources/coal instead of /) — this was intentional for consistency, flagging in case that wasn't expected.

## 🔗 Vercel Preview
[Deployment Link](https://digital-logics-studio-seven.vercel.app/profile)
