### PR TITLE
Theory tables scroll fixes

### DIFF
--- a/src/features/coal/CoalLayout.css
+++ b/src/features/coal/CoalLayout.css
@@ -136,3 +136,7 @@
 .coal-site-shell .learning-resources-main {
   padding-top: 5.25rem;
 }
+
+[data-theme="light"] .coal-layout .afhdl-pill-dot {
+  background: #4f46e5;
+}

--- a/src/features/coal/CoalPages.css
+++ b/src/features/coal/CoalPages.css
@@ -1069,6 +1069,10 @@
   color: var(--secondary-text);
 }
 
+[data-theme='light'] .coal-breadcrumb a {
+  color: #6d28d9;
+}
+
 [data-theme='light'] .coal-coming-soon {
   color: var(--text-muted);
 }

--- a/src/features/coal/CoalSidebar.css
+++ b/src/features/coal/CoalSidebar.css
@@ -176,3 +176,10 @@
   opacity: 0.75;
 }
 .coal-folder-sidebar-home-btn:hover { opacity: 1; }
+[data-theme="light"] .coal-folder-sidebar-folder-index,
+[data-theme="light"] .coal-folder-sidebar-folder-label {
+  color: #6d28d9;
+}
+[data-theme="light"] .coal-folder-sidebar-subitem.is-active {
+  color: #6d28d9;
+}

--- a/src/features/coal/components/CoalTopicCard.css
+++ b/src/features/coal/components/CoalTopicCard.css
@@ -593,3 +593,7 @@
   color: var(--text-muted);
 }
 
+[data-theme='light'] .coal-topic-preview-list li::marker {
+  color: #6d28d9;
+}
+

--- a/src/features/dld-theory/arithmetic-hdl/AFHDLLayout.css
+++ b/src/features/dld-theory/arithmetic-hdl/AFHDLLayout.css
@@ -1202,4 +1202,12 @@
     width: 100%;
   }
 }
+/* ── Light theme: darken hardcoded indigo accent (was unthemed) ── */
+[data-theme="light"] .afhdl-category-pill {
+  color: #4f46e5;
+}
+[data-theme="light"] .afhdl-pill-dot {
+  background: #4f46e5;
+}
+
 

--- a/src/features/dld-theory/boolean-algebra/BALayout.css
+++ b/src/features/dld-theory/boolean-algebra/BALayout.css
@@ -1281,3 +1281,16 @@
   }
 }
 
+/* ── Light theme: darken hardcoded purple accents (were unthemed) ── */
+[data-theme="light"] .ba-category-pill,
+[data-theme="light"] .ba-hero-badge-num,
+[data-theme="light"] .ba-hero-highlight h3,
+[data-theme="light"] .ba-nav-check,
+[data-theme="light"] .ba-layout .highlight,
+[data-theme="light"] .ba-layout .law-name {
+  color: #6d28d9;
+}
+[data-theme="light"] .ba-pill-dot {
+  background: #6d28d9;
+}
+

--- a/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
+++ b/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
@@ -28,6 +28,7 @@ const CombinationalLayout = ({
     intro={intro}
     highlights={highlights}
     pages={combinationalPages}
+    overviewPath={combinationalPages[0]?.path}
     topicLabel="Combinational Circuits"
     sidebarTitle="Combinational Circuits"
     sidebarCopy="Move through signal routing, encoding, decoding, and selection with one premium lesson framework."

--- a/src/features/dld-theory/number-systems/components/NSLayout.jsx
+++ b/src/features/dld-theory/number-systems/components/NSLayout.jsx
@@ -27,6 +27,7 @@ const NSLayout = ({ title, subtitle, intro, highlights = [], children }) => (
       highlights.length ? highlights : NS_DEFAULT_HIGHLIGHTS[title] || []
     }
     pages={nsPages}
+    overviewPath={nsPages[0]?.path}
     topicLabel="Number Systems"
     sidebarTitle="Number Systems"
     sidebarCopy="Move across binary, decimal, octal, and hexadecimal with one consistent premium conversion workspace."

--- a/src/features/dld-theory/registers-transfers/RegLayout.jsx
+++ b/src/features/dld-theory/registers-transfers/RegLayout.jsx
@@ -17,6 +17,7 @@ const RegLayout = ({ children, title, subtitle }) => (
     title={title}
     subtitle={subtitle}
     pages={regPages}
+    overviewPath={regPages[0]?.path}
     topicLabel="Registers & Transfers"
     sidebarTitle="Registers & Transfers"
     sidebarCopy="Explore storage, shifting, loading, and counting patterns through one polished navigation system."

--- a/src/features/dld-theory/sequential-circuits/SeqFlipFlops.jsx
+++ b/src/features/dld-theory/sequential-circuits/SeqFlipFlops.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import SeqLayout from "./SeqLayout";
 import SeqTable from "./components/SeqTable";
+import { useTheme } from "../../../shared/context/ThemeContext";
 
 /* ─────────────────────────────────────────────
    DATA TABLES
@@ -113,6 +114,11 @@ const MasterSlaveWalkthrough = () => {
   const [step, setStep] = useState(0);
   const s = msSteps[step];
 
+  const { theme } = useTheme();
+  const frozenFill = theme === "light" ? "#f1f5f9" : "rgba(30,27,75,0.7)";
+  const frozenStroke = theme === "light" ? "#cbd5e1" : "#475569";
+  const frozenText = theme === "light" ? "#94a3b8" : "#64748b";
+
   return (
     <div className="seq-ms-walkthrough">
       {/* Diagram */}
@@ -162,8 +168,8 @@ const MasterSlaveWalkthrough = () => {
             width="160"
             height="80"
             rx="10"
-            fill={s.masterOpen ? "rgba(245,158,11,0.12)" : "rgba(30,27,75,0.7)"}
-            stroke={s.masterOpen ? "#f59e0b" : "#475569"}
+            fill={s.masterOpen ? "rgba(245,158,11,0.12)" : frozenFill}
+            stroke={s.masterOpen ? "#f59e0b" : frozenStroke}
             strokeWidth={s.masterOpen ? "2.5" : "1.5"}
             style={{ transition: "all 0.4s" }}
           />
@@ -171,7 +177,7 @@ const MasterSlaveWalkthrough = () => {
             x="160"
             y="88"
             fontSize="13"
-            fill={s.masterOpen ? "#fbbf24" : "#64748b"}
+            fill={s.masterOpen ? "#fbbf24" : frozenText}
             textAnchor="middle"
             fontWeight="700"
             style={{ transition: "all 0.4s" }}
@@ -182,7 +188,7 @@ const MasterSlaveWalkthrough = () => {
             x="160"
             y="107"
             fontSize="10"
-            fill={s.masterOpen ? "#f59e0b" : "#475569"}
+            fill={s.masterOpen ? "#f59e0b" : frozenStroke}
             textAnchor="middle"
             style={{ transition: "all 0.4s" }}
           >
@@ -230,8 +236,8 @@ const MasterSlaveWalkthrough = () => {
             width="160"
             height="80"
             rx="10"
-            fill={s.slaveOpen ? "rgba(16,185,129,0.12)" : "rgba(30,27,75,0.7)"}
-            stroke={s.slaveOpen ? "#10b981" : "#475569"}
+            fill={s.slaveOpen ? "rgba(16,185,129,0.12)" : frozenFill}
+            stroke={s.slaveOpen ? "#10b981" : frozenStroke}
             strokeWidth={s.slaveOpen ? "2.5" : "1.5"}
             style={{ transition: "all 0.4s" }}
           />
@@ -239,7 +245,7 @@ const MasterSlaveWalkthrough = () => {
             x="390"
             y="88"
             fontSize="13"
-            fill={s.slaveOpen ? "#34d399" : "#64748b"}
+            fill={s.slaveOpen ? "#34d399" : frozenText}
             textAnchor="middle"
             fontWeight="700"
             style={{ transition: "all 0.4s" }}
@@ -250,7 +256,7 @@ const MasterSlaveWalkthrough = () => {
             x="390"
             y="107"
             fontSize="10"
-            fill={s.slaveOpen ? "#10b981" : "#475569"}
+            fill={s.slaveOpen ? "#10b981" : frozenStroke}
             textAnchor="middle"
             style={{ transition: "all 0.4s" }}
           >

--- a/src/features/dld-theory/sequential-circuits/SeqLatches.jsx
+++ b/src/features/dld-theory/sequential-circuits/SeqLatches.jsx
@@ -42,7 +42,60 @@ const TIMING_CSS = `
   font-weight: 700;
   margin: 0 0 0.5rem;
 }
+  .seq-timing-section {
+  margin: 1.5rem 0 2rem;
+  border-radius: 10px;
+  background: rgba(15,23,42,0.6);
+  border: 1px solid rgba(99,102,241,0.2);
+  padding: 1.1rem 1.2rem 1rem;
+}
+.seq-timing-header {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #a5b4fc;
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.03em;
+}
+.seq-timing-desc {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin: 0 0 0.9rem;
+  line-height: 1.55;
+}
+.seq-timing-wrap { overflow-x: auto; }
+.seq-timing-scroll { min-width: 0; }
+.seq-timing-legend {
+  font-size: 0.72rem;
+  color: #64748b;
+  margin: 0.6rem 0 0;
+  letter-spacing: 0.02em;
+}
+.seq-timing-title {
+  font-size: 0.78rem;
+  color: #818cf8;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+/* ── Light theme ── */
+:root[data-theme="light"] .seq-timing-section {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.18);
+}
+:root[data-theme="light"] .seq-timing-header {
+  color: #4f46e5;
+}
+:root[data-theme="light"] .seq-timing-desc {
+  color: #475569;
+}
+:root[data-theme="light"] .seq-timing-legend {
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-timing-title {
+  color: #4f46e5;
+}
 `;
+
 const TimingStyles = () => {
   useEffect(() => {
     if (!document.getElementById("seq-timing-styles")) {

--- a/src/features/dld-theory/sequential-circuits/SeqLayout.css
+++ b/src/features/dld-theory/sequential-circuits/SeqLayout.css
@@ -1377,6 +1377,9 @@ body,
   }
 }
 
+ .seq-grid-2 > * {
+  min-width: 0;
+}
 /* Feature card styling */
 .seq-feature-card {
   display: flex;
@@ -2800,4 +2803,160 @@ body,
   border-radius: 6px;
   letter-spacing: 0.03em;
 }
+/* ═══════════════════════════════════════════════════════
+   LIGHT THEME — Flip-Flop page additions
+═══════════════════════════════════════════════════════ */
+:root[data-theme="light"] .seq-analogy-item {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.15);
+}
+:root[data-theme="light"] .seq-analogy-desc {
+  color: #475569;
+}
 
+:root[data-theme="light"] .seq-ms-walkthrough {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+:root[data-theme="light"] .seq-ms-desc {
+  color: #334155;
+}
+:root[data-theme="light"] .seq-ms-note {
+  color: #475569;
+  background: rgba(37, 99, 235, 0.05);
+  border-left-color: #2563eb;
+}
+:root[data-theme="light"] .seq-ms-controls {
+  border-top-color: rgba(37, 99, 235, 0.12);
+}
+:root[data-theme="light"] .seq-step-btn {
+  background: #f1f5f9;
+  border-color: rgba(37, 99, 235, 0.15);
+  color: #475569;
+}
+:root[data-theme="light"] .seq-step-btn:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.1);
+  color: #0f172a;
+}
+:root[data-theme="light"] .seq-dot {
+  background: rgba(37, 99, 235, 0.15);
+}
+:root[data-theme="light"] .seq-dot-active {
+  background: #2563eb;
+}
+
+:root[data-theme="light"] .seq-sim-full {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+:root[data-theme="light"] .seq-sim-header {
+  border-bottom-color: rgba(37, 99, 235, 0.12);
+}
+:root[data-theme="light"] .seq-sim-title {
+  color: #0f172a;
+}
+:root[data-theme="light"] .seq-sim-reset {
+  color: #475569;
+  border-color: rgba(37, 99, 235, 0.15);
+}
+:root[data-theme="light"] .seq-sim-controls {
+  border-right-color: rgba(37, 99, 235, 0.12);
+}
+:root[data-theme="light"] .seq-sim-sig-label,
+:root[data-theme="light"] .seq-out-lbl,
+:root[data-theme="light"] .seq-wave-title,
+:root[data-theme="light"] .seq-wave-label {
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-bit-low {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-clk-edge-btn {
+  background: rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: #2563eb;
+}
+:root[data-theme="light"] .seq-clk-edge-btn:hover {
+  background: rgba(37, 99, 235, 0.18);
+}
+:root[data-theme="light"] .seq-out-box {
+  background: #f8fafc;
+  border-color: rgba(37, 99, 235, 0.12);
+}
+:root[data-theme="light"] .seq-val-low {
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-sim-log {
+  border-top-color: rgba(37, 99, 235, 0.12);
+}
+
+:root[data-theme="light"] .seq-sim-mini {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.15);
+}
+:root[data-theme="light"] .seq-sim-label,
+:root[data-theme="light"] .seq-out-label,
+:root[data-theme="light"] .seq-sim-state {
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-sim-toggle.off {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-out-val {
+  color: #0f172a;
+}
+:root[data-theme="light"] .seq-sim-state {
+  border-top-color: rgba(37, 99, 235, 0.12);
+}
+:root[data-theme="light"] .seq-sim-log-mini {
+  border-top-color: rgba(37, 99, 235, 0.12);
+}
+
+:root[data-theme="light"] .seq-ff-type-btn {
+  background: #f8fafc;
+  border-color: rgba(37, 99, 235, 0.15);
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-ff-type-btn:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+:root[data-theme="light"] .seq-ff-summary {
+  background: #f8fafc;
+  color: #475569;
+}
+
+:root[data-theme="light"] .seq-counter-demo {
+  background: #ffffff;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+:root[data-theme="light"] .seq-counter-title,
+:root[data-theme="light"] .seq-counter-ff-label {
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-q-low {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+  color: #64748b;
+}
+:root[data-theme="light"] .seq-counter-decimal {
+  color: #0f172a;
+}
+:root[data-theme="light"] .seq-count-step {
+  background: #f1f5f9;
+  border-color: rgba(37, 99, 235, 0.15);
+  color: #64748b;
+}
+
+:root[data-theme="light"] .seq-meta-item {
+  background: #f8fafc;
+  border-color: rgba(37, 99, 235, 0.12);
+}
+
+:root[data-theme="light"] .seq-equation {
+  background: rgba(37, 99, 235, 0.08);
+  color: #2563eb;
+}

--- a/src/features/dld-theory/sequential-circuits/SeqLayout.css
+++ b/src/features/dld-theory/sequential-circuits/SeqLayout.css
@@ -25,11 +25,6 @@
   --glass: rgba(11, 19, 36, 0.62);
 }
 
-html,
-body,
-#root {
-  height: 100%;
-}
 
 .seq-layout {
   min-height: 100vh;

--- a/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
+++ b/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
@@ -17,6 +17,7 @@ const SeqLayout = ({ children, title, subtitle }) => (
     title={title}
     subtitle={subtitle}
     pages={seqPages}
+    overviewPath={seqPages[0]?.path}
     topicLabel="Sequential Circuits"
     sidebarTitle="Sequential Circuits"
     sidebarCopy="Follow one state-logic chapter at a time with the same premium learning path used across the platform."

--- a/src/shared/layouts/AdvancedLogicLayout.jsx
+++ b/src/shared/layouts/AdvancedLogicLayout.jsx
@@ -28,6 +28,7 @@ const AdvancedLogicLayout = ({
     intro={intro}
     highlights={highlights}
     pages={advancedLogicPages}
+    overviewPath={advancedLogicPages[0]?.path}
     topicLabel="Advanced Logic"
     sidebarTitle="Advanced Logic"
     sidebarCopy="Study optimization, universal construction, parity, and deeper reasoning inside the same premium shell."

--- a/src/shared/styles/light-theme-overrides.css
+++ b/src/shared/styles/light-theme-overrides.css
@@ -477,3 +477,37 @@
 [data-theme='light'] .hint {
   color: var(--text-muted);
 }
+/* ── Theory content — tables, cards, code blocks, quiz ─────────────────── */
+[data-theme='light'] .theory-topic-content {
+  --t-text: #0f172a;
+  --t-muted: #475569;
+  --t-border: rgba(148, 163, 184, 0.25);
+  --t-card-bg: rgba(37, 99, 235, 0.04);
+}
+
+[data-theme='light'] .theory-table th,
+[data-theme='light'] .theory-table td {
+  border-bottom-color: var(--t-border);
+}
+
+[data-theme='light'] .theory-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+[data-theme='light'] .theory-code-block {
+  background: #f1f5f9;
+}
+
+[data-theme='light'] .theory-chip {
+  background: #f8fafc;
+}
+
+/* ── Global fallback: plain <td> from public/styles.css defaults to a
+   dark navy background with no light-theme handling. Scoped elements
+   (e.g. .seq-table-cell) already override this correctly — this only
+   catches bare, unstyled table cells site-wide (Circuit Forge's truth
+   table, and any Sequential Circuits table without a specific class). ─ */
+[data-theme='light'] td {
+  background: #ffffff;
+  color: #0f172a;
+}

--- a/src/shared/utils/ScrollToTop.jsx
+++ b/src/shared/utils/ScrollToTop.jsx
@@ -1,14 +1,19 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 const ScrollToTop = () => {
-    const { pathname } = useLocation();
+  const { pathname } = useLocation();
 
-    useEffect(() => {
-        window.scrollTo(0, 0);
-    }, [pathname]);
+  useLayoutEffect(() => {
+    // Browsers try to auto-restore scroll position on SPA navigation,
+    // which can override our own reset below. Take manual control once.
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+    window.scrollTo(0, 0);
+  }, [pathname]);
 
-    return null;
+  return null;
 };
 
 export default ScrollToTop;


### PR DESCRIPTION
## 📌 Summary
Fixes light-theme styling bugs across DLD/COAL theory content (tables, headings, diagrams) and a scroll-restoration bug affecting page navigation and auto-mark-as-read, isolated to Sequential Circuits.

## 🔗 Related Issue
Closes #ISSUE_NUMBER

## 🛠️ Changes Made
Fixed missing/inconsistent light-theme colors on .theory-table, global <td> fallback, and several hardcoded purple/indigo accents across BALayout.css, AFHDLLayout.css, CoalLayout.css, CoalSidebar.css, CoalTopicCard.css
Fixed Sequential Circuits' Flip-Flop page widgets (analogy cards, Master-Slave simulator, D Flip-Flop simulator, counter demo) having no light-theme styling at all
Fixed SeqStateReduction's grid layout overflowing off-screen in light theme only
Fixed browser scroll-restoration overriding ScrollToTop's reset on SPA navigation (was causing "Next" to land mid-page instead of at top, sitewide)
Removed a leftover unscoped html/body/#root CSS rule in SeqLayout.css that broke scroll-height calculations specifically on Sequential Circuits pages

## ✅ Testing
SManually verified in both themes across Boolean Algebra, Number Systems, Combinational Circuits, Sequential Circuits, Registers, Advanced Logic, and COAL topic pages.


## 👥 Reviewer Notes
SeqLayout.css still contains unused legacy CSS (.seq-main, .seq-body, etc. from before this page used the shared layout shell) — left in place since nothing currently references those classes, but worth a cleanup pass separately.

## 🔗 Vercel Preview
[Deployment Link](https://digital-logics-studio-seven.vercel.app/profile)
