### PR TITLE
Fix light-theme contrast, add previous-part navigation, fix Mark as Read scroll bug, clean up navbar

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -4883,7 +4883,7 @@ select:focus-visible {
 .quat-content {
   margin-top: 15px;
   padding: 15px;
-  background: rgba(0, 0, 0, 0.2);
+   background: var(--card-bg-solid);
   border-left: 3px solid var(--accent-secondary);
   animation: fadeIn 0.3s ease;
 }

--- a/src/features/coal/data/CoalDiagrams.jsx
+++ b/src/features/coal/data/CoalDiagrams.jsx
@@ -764,7 +764,7 @@ export function RaidComparisonDiagram() {
         {/* RAID 0 (Striping) */}
         <text x="90" y="25" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "13px" }}>RAID 0 (Striping)</text>
         {/* Disk 0 */}
-        <rect x="25" y="45" width="60" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="25" y="45" width="60" height="150" rx="4"fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="55" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 1</text>
         <rect x="30" y="55" width="50" height="25" rx="2" className="coal-diagram__box coal-diagram__box--cpu" />
         <text x="55" y="72" textAnchor="middle" className="coal-diagram__label">Block 1</text>
@@ -774,7 +774,7 @@ export function RaidComparisonDiagram() {
         <text x="55" y="132" textAnchor="middle" className="coal-diagram__label">Block 5</text>
         
         {/* Disk 1 */}
-        <rect x="95" y="45" width="60" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="95" y="45" width="60" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="125" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 2</text>
         <rect x="100" y="55" width="50" height="25" rx="2" className="coal-diagram__box coal-diagram__box--cpu" />
         <text x="125" y="72" textAnchor="middle" className="coal-diagram__label">Block 2</text>
@@ -788,7 +788,7 @@ export function RaidComparisonDiagram() {
         {/* RAID 1 (Mirroring) */}
         <text x="270" y="25" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "13px" }}>RAID 1 (Mirroring)</text>
         {/* Disk 0 */}
-        <rect x="205" y="45" width="60" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="205" y="45" width="60" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="235" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 1</text>
         <rect x="210" y="55" width="50" height="25" rx="2" className="coal-diagram__box coal-diagram__box--mem" />
         <text x="235" y="72" textAnchor="middle" className="coal-diagram__label">Block 1</text>
@@ -798,7 +798,7 @@ export function RaidComparisonDiagram() {
         <text x="235" y="132" textAnchor="middle" className="coal-diagram__label">Block 3</text>
         
         {/* Disk 1 */}
-        <rect x="275" y="45" width="60" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="275" y="45" width="60" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="305" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 2</text>
         <rect x="280" y="55" width="50" height="25" rx="2" className="coal-diagram__box coal-diagram__box--mem" />
         <text x="305" y="72" textAnchor="middle" className="coal-diagram__label">Block 1</text>
@@ -812,7 +812,7 @@ export function RaidComparisonDiagram() {
         {/* RAID 5 (Parity) */}
         <text x="450" y="25" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "13px" }}>RAID 5 (Distributed Parity)</text>
         {/* Disk 0 */}
-        <rect x="385" y="45" width="40" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="385" y="45" width="40" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="405" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 1</text>
         <rect x="390" y="55" width="30" height="25" rx="2" className="coal-diagram__box coal-diagram__box--cpu" />
         <text x="405" y="72" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "10px" }}>Block 1</text>
@@ -822,7 +822,7 @@ export function RaidComparisonDiagram() {
         <text x="405" y="132" textAnchor="middle" className="coal-diagram__label" style={{ fill: "#fbbf24", fontSize: "10px" }}>P (5-6)</text>
         
         {/* Disk 1 */}
-        <rect x="430" y="45" width="40" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="430" y="45" width="40" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="450" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 2</text>
         <rect x="435" y="55" width="30" height="25" rx="2" className="coal-diagram__box coal-diagram__box--cpu" />
         <text x="450" y="72" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "10px" }}>Block 2</text>
@@ -832,7 +832,7 @@ export function RaidComparisonDiagram() {
         <text x="450" y="132" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "10px" }}>Block 5</text>
 
         {/* Disk 2 */}
-        <rect x="475" y="45" width="40" height="150" rx="4" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="475" y="45" width="40" height="150" rx="4" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         <text x="495" y="180" textAnchor="middle" className="coal-diagram__sublabel">Disk 3</text>
         <rect x="480" y="55" width="30" height="25" rx="2" className="coal-diagram__box coal-diagram__box--io" />
         <text x="495" y="72" textAnchor="middle" className="coal-diagram__label" style={{ fill: "#fbbf24", fontSize: "10px" }}>P (1-2)</text>
@@ -882,7 +882,7 @@ export function CiscRiscComparisonDiagram() {
         {/* RISC Column */}
         <text x="405" y="25" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "14px" }}>RISC (e.g. ARM, RISC-V)</text>
 
-        <rect x="295" y="45" width="220" height="110" rx="6" fill="rgba(15, 23, 42, 0.4)" stroke="rgba(167, 139, 250, 0.3)" />
+        <rect x="295" y="45" width="220" height="110" rx="6" fill="var(--card-bg-solid)" stroke="rgba(167, 139, 250, 0.3)" />
         
         <rect x="305" y="55" width="200" height="22" rx="3" className="coal-diagram__box coal-diagram__box--mem" />
         <text x="405" y="70" textAnchor="middle" className="coal-diagram__label" style={{ fontSize: "10px" }}>LDR R1, [MemA]   ; Load value</text>

--- a/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
+++ b/src/features/dld-theory/combinational-circuits/CombinationalLayout.jsx
@@ -15,6 +15,11 @@ const nextPart =
 const nextPartPath = nextPart?.modules?.[0]?.path || null;
 const nextPartLabel = nextPart?.title || null;
 
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
+
 const CombinationalLayout = ({
   title,
   subtitle,
@@ -42,6 +47,8 @@ const CombinationalLayout = ({
     nextPartLabel={nextPartLabel}
     sidebarFooterLink="/resources/dld"
     sidebarFooterLabel="← DLD home"
+     prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/EncoderPage.jsx
+++ b/src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/EncoderPage.jsx
@@ -157,7 +157,7 @@ const EncoderPage = () => {
               <li>For output bit Aₖ, find every index where <strong style={{ color: COLORS.warn }}>bit k = 1</strong> in binary</li>
               <li>OR those input lines together — that's your equation!</li>
             </ol>
-            <div style={{ marginTop: "14px", padding: "12px", background: "rgba(0,0,0,0.3)", borderRadius: "8px", fontFamily: "monospace", fontSize: "0.87rem" }}>
+            <div style={{ marginTop: "14px", padding: "12px", background: COLORS.darkBg, borderRadius: "8px", fontFamily: "monospace", fontSize: "0.87rem" }}>
               <span style={{ color: COLORS.warn }}>Example — A0 in 8-to-3 encoder:</span><br />
               <span style={{ color: COLORS.textSecondary }}>Indices 0–7 in binary: </span>
               <span style={{ color: COLORS.textDim }}>000 001 010 011 100 101 110 111</span><br />

--- a/src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/components/EncoderSimulator.jsx
+++ b/src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/components/EncoderSimulator.jsx
@@ -199,7 +199,7 @@ const EncoderSimulator = ({ config, inputVals, setInputVals }) => {
         </div>
 
         {/* Encoding result summary */}
-        <div style={{ padding: "14px", background: "rgba(8,14,30,0.8)", border: "1px solid rgba(99,102,241,0.25)", borderRadius: "10px" }}>
+       <div style={{ padding: "14px", background: COLORS.darkBg, border: "1px solid rgba(99,102,241,0.25)", borderRadius: "10px" }}>
           {result.active >= 0 ? (
             <>
               <div style={{ color: "#86efac", fontSize: "0.78rem", fontWeight: "700", marginBottom: "6px" }}>ENCODING RESULT</div>

--- a/src/features/dld-theory/combinational-circuits/encoder-decoder/shared/theme.js
+++ b/src/features/dld-theory/combinational-circuits/encoder-decoder/shared/theme.js
@@ -16,7 +16,7 @@ export const COLORS = {
 
   // Brand / accent
   indigo: "#6366f1",
-  indigoLight: "#a5b4fc",
+  indigoLight: "var(--indigo-accent-text)",
   indigoMuted: "rgba(99,102,241,0.2)",
 
   // Signal states

--- a/src/features/dld-theory/memory/MemoryLayout.jsx
+++ b/src/features/dld-theory/memory/MemoryLayout.jsx
@@ -6,6 +6,13 @@ import {
   MEMORY_PATH_TO_SUBTOPIC_ID,
   MEMORY_TOPIC,
 } from "./memoryConfig";
+import { dldCourseParts } from "../../../shared/data/dldCourseOutline";
+
+const currentPartIndex = dldCourseParts.findIndex((p) => p.id === "memory-systems");
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
 
 const MemoryLayout = ({ title, kicker, description, children }) => (
   <TopicLayout
@@ -22,6 +29,8 @@ const MemoryLayout = ({ title, kicker, description, children }) => (
       topic: MEMORY_TOPIC,
       pathToSubtopicId: MEMORY_PATH_TO_SUBTOPIC_ID,
     }}
+    prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/number-systems/components/NSLayout.jsx
+++ b/src/features/dld-theory/number-systems/components/NSLayout.jsx
@@ -18,6 +18,11 @@ const nextPart =
 const nextPartPath = nextPart?.modules?.[0]?.path || null;
 const nextPartLabel = nextPart?.title || null;
 
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
+
 const NSLayout = ({ title, subtitle, intro, highlights = [], children }) => (
   <TopicLayout
     title={title}
@@ -43,6 +48,8 @@ const NSLayout = ({ title, subtitle, intro, highlights = [], children }) => (
     nextPartLabel={nextPartLabel}
     sidebarFooterLink="/resources/dld"
     sidebarFooterLabel="← DLD home"
+    prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/registers-transfers/RegLayout.jsx
+++ b/src/features/dld-theory/registers-transfers/RegLayout.jsx
@@ -12,6 +12,11 @@ const nextPart =
 const nextPartPath = nextPart?.modules?.[0]?.path || null;
 const nextPartLabel = nextPart?.title || null;
 
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
+
 const RegLayout = ({ children, title, subtitle }) => (
   <TopicLayout
     title={title}
@@ -32,6 +37,8 @@ const RegLayout = ({ children, title, subtitle }) => (
     nextPartLabel={nextPartLabel}
     sidebarFooterLink="/resources/dld"
     sidebarFooterLabel="← DLD home"
+        prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
+++ b/src/features/dld-theory/sequential-circuits/SeqLayout.jsx
@@ -12,6 +12,11 @@ const nextPart =
 const nextPartPath = nextPart?.modules?.[0]?.path || null;
 const nextPartLabel = nextPart?.title || null;
 
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
+
 const SeqLayout = ({ children, title, subtitle }) => (
   <TopicLayout
     title={title}
@@ -32,6 +37,8 @@ const SeqLayout = ({ children, title, subtitle }) => (
     nextPartLabel={nextPartLabel}
     sidebarFooterLink="/resources/dld"
     sidebarFooterLabel="← DLD home"
+    prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@ html[data-theme='dark'],
   --card-border: rgba(148, 163, 184, 0.2);
   --border-color: rgba(148, 163, 184, 0.1);
   --secondary-text: #94a3b8;
+  --indigo-accent-text: #a5b4fc;
   --accent-color: #3b82f6;
   --nav-bg: rgba(2, 6, 23, 0.8);
   --brand-gradient: linear-gradient(to right, #ffffff, #94a3b8);
@@ -55,6 +56,7 @@ html[data-theme='dark'],
   --card-border-width: 1px;
   --border-color: rgba(59, 130, 246, 0.16);
   --secondary-text: #334155;
+  --indigo-accent-text: #4338ca;
   --accent-color: #2563eb;
   --nav-bg: rgba(248, 250, 255, 0.88);
   --brand-gradient: linear-gradient(to right, #0f172a, #334155);

--- a/src/shared/components/navbar/BrandLogo.jsx
+++ b/src/shared/components/navbar/BrandLogo.jsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { Link } from "react-router-dom";
 
 export function BrandLogo({ tagline, onClick }) {
   return (
-    <Link
-      to="/"
+    <div
       className="home-brand home-brand-link"
       aria-label="Go to home page"
-      onClick={onClick}
     >
       <div className="home-logo-container">
         <svg viewBox="0 0 100 100" className="home-logo-svg">
@@ -42,6 +39,6 @@ export function BrandLogo({ tagline, onClick }) {
         <span className="home-title">Boolforge</span>
         <span className="home-tagline">{tagline}</span>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/src/shared/components/navbar/Navbar.jsx
+++ b/src/shared/components/navbar/Navbar.jsx
@@ -1,5 +1,6 @@
 import { memo, useMemo, useState } from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
+//import { Home } from "lucide-react";   
 import { useAuth } from "../../../auth/context/AuthContext";
 
 import { BrandLogo } from "./BrandLogo";
@@ -7,12 +8,14 @@ import { ProfileDropdown } from "./ProfileDropdown";
 import ThemeToggler from "./ThemeToggler";
 
 const DLD_NAV_LINKS = [
+  { to: "/", label: "Home", end: true }, 
   { to: "/problems", label: "Problems" },
   { to: "/boolforge", label: "Circuit Forge" },
   { to: "/kmapgenerator", label: "K-Map Studio" },
 ];
 
 const COAL_NAV_LINKS = [
+  { to: "/", label: "Home", end: true }, 
   { to: "/resources/coal", label: "COAL Home", end: true },
   { to: "/resources/coal/theory", label: "Theory", matchTheory: true },
   { to: "/resources/coal/practical", label: "Practical" },
@@ -34,7 +37,9 @@ function NavbarBase({ toggleTheme, theme, onHomeClick, onToggleNavbar }) {
   const location = useLocation();
 
   const onCoalTrack = isCoalRoute(location.pathname);
-  const navLinks = onCoalTrack ? COAL_NAV_LINKS : DLD_NAV_LINKS;
+  const navLinks = (onCoalTrack ? COAL_NAV_LINKS : DLD_NAV_LINKS).filter(
+  (link) => !(link.to === "/" && location.pathname === "/"),
+);
   const brandTagline = onCoalTrack
     ? "Computer Organization & Assembly"
     : "The Digital Logic Playground";
@@ -86,11 +91,13 @@ function NavbarBase({ toggleTheme, theme, onHomeClick, onToggleNavbar }) {
   return (
     <header className="home-header">
       <div className="home-header-inner">
-        <BrandLogo tagline={brandTagline} onClick={handleHomeClick} />
+       <BrandLogo tagline={brandTagline} onClick={handleHomeClick} />
 
-        <nav className="home-nav" aria-label="Main navigation">
-          {renderNavLinks("home-nav-link")}
+      <nav className="home-nav" aria-label="Main navigation">
+       {renderNavLinks("home-nav-link")}
         </nav>
+
+
 
         <div className="home-nav-controls">
           {!loading && (

--- a/src/shared/components/topics/PremiumLearningShell.jsx
+++ b/src/shared/components/topics/PremiumLearningShell.jsx
@@ -94,8 +94,10 @@ const PremiumLearningShell = ({
   rootClassName = "",
    sidebarFooterLink = "/",
   sidebarFooterLabel = "← Back to All Topics",
-  nextPartPath = null,      // ← add
+  nextPartPath = null,     
   nextPartLabel = null,
+  prevPartPath = null,      
+  prevPartLabel = null,
 }) => {
   const location = useLocation();
   const { theme, toggle: toggleTheme } = useTheme();
@@ -217,9 +219,12 @@ const PremiumLearningShell = ({
 // page. Only fires once per page visit, and only if not already read
 // — scrolling back up/down again after that does nothing further.
 const autoMarkedRef = useRef(false);
+const scrollArmedRef = useRef(false);
 
 useEffect(() => {
   autoMarkedRef.current = false;
+  scrollArmedRef.current = false;
+  window.scrollTo({ top: 0, left: 0, behavior: "instant" });
 }, [currentPath]);
 
 useEffect(() => {
@@ -227,6 +232,16 @@ useEffect(() => {
 
   const checkScrollProgress = () => {
     if (autoMarkedRef.current || isRead) return;
+
+    // Ignore scroll events until we've actually observed the page
+    // sitting near the top at least once. Protects against a leftover
+    // smooth-scroll animation (or the browser clamping an old scroll
+    // position into a shorter new page) firing scroll events with a
+    // stale, still-high scrollY right after navigation.
+    if (!scrollArmedRef.current) {
+      if (window.scrollY > 40) return;
+      scrollArmedRef.current = true;
+    }
 
     const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight;
     if (scrollableHeight <= 0) return;
@@ -241,6 +256,7 @@ useEffect(() => {
   window.addEventListener("scroll", checkScrollProgress, { passive: true });
   return () => window.removeEventListener("scroll", checkScrollProgress);
 }, [trackedTopic, subtopicId, catalog, isRead, toggleCompletion]);
+
 
   const pageDone = (pageIndex, page) => {
     if (isSidebarItemDone) return isSidebarItemDone(page, completedSubtopics);
@@ -467,32 +483,32 @@ useEffect(() => {
 
           <footer className="afhdl-footer-nav">
             {prev ? (
-              <NavLink to={prev.path} className="afhdl-footer-link">
-                <span className="afhdl-footer-arrow">
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 20 20"
-                    fill="none"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M13 5l-5 5 5 5"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </span>
-                <span>
-                  <span className="afhdl-footer-label">Previous</span>
-                  <span className="afhdl-footer-title">{prev.label}</span>
-                </span>
-              </NavLink>
-            ) : (
-              <div />
-            )}
+  <NavLink to={prev.path} className="afhdl-footer-link">
+    <span className="afhdl-footer-arrow">
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+        <path d="M13 5l-5 5 5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+    <span>
+      <span className="afhdl-footer-label">Previous</span>
+      <span className="afhdl-footer-title">{prev.label}</span>
+    </span>
+  </NavLink>
+) : prevPartPath ? (
+  <Link to={prevPartPath} className="afhdl-footer-link">
+    <span className="afhdl-footer-arrow">
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+        <path d="M13 5l-5 5 5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+    <span>
+      <span className="afhdl-footer-label">Previous part</span>
+      <span className="afhdl-footer-title">{prevPartLabel}</span>
+    </span>
+  </Link>
+) : (
+  <div />
+)}
 
             <div className="afhdl-footer-right">
               {tracking && subtopicId ? (

--- a/src/shared/components/topics/TopicLayout.jsx
+++ b/src/shared/components/topics/TopicLayout.jsx
@@ -22,6 +22,8 @@ const TopicLayout = ({
   sidebarFooterLabel = "← Back to All Topics",
   nextPartPath = null,
   nextPartLabel = null,
+  prevPartPath = null,     
+  prevPartLabel = null,
   children,
 }) => (
   <PremiumLearningShell
@@ -45,6 +47,8 @@ const TopicLayout = ({
     tracking={tracking}
     nextPartPath={nextPartPath}
     nextPartLabel={nextPartLabel}
+     prevPartPath={prevPartPath}    
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </PremiumLearningShell>

--- a/src/shared/layouts/AdvancedLogicLayout.jsx
+++ b/src/shared/layouts/AdvancedLogicLayout.jsx
@@ -15,6 +15,11 @@ const nextPart =
 const nextPartPath = nextPart?.modules?.[0]?.path || null;
 const nextPartLabel = nextPart?.title || null;
 
+const prevPart =
+  currentPartIndex > 0 ? dldCourseParts[currentPartIndex - 1] : null;
+const prevPartPath = prevPart?.modules?.[0]?.path || null;
+const prevPartLabel = prevPart?.title || null;
+
 const AdvancedLogicLayout = ({
   title,
   subtitle,
@@ -42,6 +47,8 @@ const AdvancedLogicLayout = ({
     nextPartLabel={nextPartLabel}
     sidebarFooterLink="/resources/dld"
     sidebarFooterLabel="← DLD home"
+    prevPartPath={prevPartPath}
+    prevPartLabel={prevPartLabel}
   >
     {children}
   </TopicLayout>

--- a/src/shared/layouts/TheoryLayout.jsx
+++ b/src/shared/layouts/TheoryLayout.jsx
@@ -34,11 +34,31 @@ export default function TheoryLayout({ track, children, title, subtitle, intro, 
     : null;
       const nextPartLabel = nextPart?.title || null;
 
-  const currentPartPages = currentPart.modules.map((module) => ({
-    path: utils.getTopicPath(module.slug),
-    label: module.title,
-    description: module.description || `Part ${currentPart.part} · ${currentPart.title}`,
-  }));
+        const prevPart =
+    currentPartIndex > 0 ? courseParts[currentPartIndex - 1] : null;
+  const prevPartPath = prevPart?.modules?.[0]
+    ? utils.getTopicPath(prevPart.modules[0].slug)
+    : null;
+  const prevPartLabel = prevPart?.title || null;
+
+ const currentPartPages = currentPart.modules.map((module) => ({
+  path: utils.getTopicPath(module.slug),
+  label: module.title,
+  description: module.description || `Part ${currentPart.part} · ${currentPart.title}`,
+}));
+
+// Scope path→subtopicId to just this part's modules, so the progress
+// ring's "X of Y" count matches the same pages shown in this view — not
+// every topic in the whole course. This matters most for COAL, which
+// tracks all its progress under one shared topic id across every part;
+// without this, a topic completed back in Part 1 would still count
+// toward Part 2's ring.
+const currentPartPathToSubtopicId = Object.fromEntries(
+  currentPart.modules.map((module) => [
+    utils.getTopicPath(module.slug),
+    module.subtopicId || module.slug,
+  ]),
+);
 
   const pages = track.pagesScope === "all" ? utils.buildTopicPages() : currentPartPages;
 
@@ -72,9 +92,11 @@ export default function TheoryLayout({ track, children, title, subtitle, intro, 
       rootClassName={track.rootClassName}
       sidebarFooterLink={track.homePath}
       sidebarFooterLabel={`← ${track.id === "coal" ? "COAL" : "DLD"} home`}
-      tracking={{ topic, pathToSubtopicId: utils.PATH_TO_SUBTOPIC_ID }}
+      tracking={{ topic, pathToSubtopicId: currentPartPathToSubtopicId }}
       nextPartPath={nextPartPath}
       nextPartLabel={nextPartLabel}
+      prevPartPath={prevPartPath}
+      prevPartLabel={prevPartLabel}
     >
       {children}
     </TopicLayout>


### PR DESCRIPTION
…rk as Read scroll bug, and clean up navbar

### Summary

Adds "previous part" navigation links (DLD + COAL), fixes a false-positive "Marked as Read" bug on Next/Previous navigation, cleans up the top navbar, and fixes a few remaining light-theme contrast issues.

---

## 1. Previous-part navigation link

**Before:** the first page of every part showed no "Previous" link in the footer, even though a symmetric "next part" continuation link already existed for the last page of a part.

**Fix:** mirrored the existing `nextPartPath`/`nextPartLabel` mechanism with a new `prevPartPath`/`prevPartLabel`.

- `src/shared/components/topics/PremiumLearningShell.jsx` — added `prevPartPath`/`prevPartLabel` props; footer now renders a "Previous part" link when there's no in-part previous page but a previous part exists.
- `src/shared/components/topics/TopicLayout.jsx` — passthrough for the two new props.
- `src/shared/layouts/TheoryLayout.jsx` — the actual live render path for `/memory/*`, `/universal-gates`, `/odd-function`, `/gates`, and all COAL topic pages — computes `prevPart`/`prevPartPath`/`prevPartLabel`, mirroring the existing `nextPart` logic.
- `src/shared/layouts/AdvancedLogicLayout.jsx`, `src/features/dld-theory/memory/MemoryLayout.jsx`, `NSLayout.jsx`, `RegLayout.jsx`, `SeqLayout.jsx`, `CombinationalLayout.jsx` — same `prevPart` computation added for consistency across the standalone layout files.

## 2. False "Marked as Read" on Next/Previous navigation

**Before:** clicking "Next"/"Previous" instantly marked the new page as read with zero scrolling, while sidebar navigation worked correctly.

**Root cause:** Next/Previous is clicked from max scroll on the old page. The scroll-reset effect could still be mid-animation to the top when the new page's (often shorter) height made the still-high scroll position register as ≥90% before any real scrolling happened.

**Fix (`PremiumLearningShell.jsx`):** reset scroll with `behavior: "instant"`, and added a `scrollArmedRef` guard so the scroll-progress listener ignores all events until it has observed the page sitting near the top at least once after navigation.

## 3. Navbar cleanup

- `src/shared/components/navbar/BrandLogo.jsx` — logo no longer navigates (redundant with the new Home link).
- `src/shared/components/navbar/Navbar.jsx` — added `Home` as a real nav-link entry (inherits the same hover/active styling as Problems/Circuit Forge/K-Map Studio, desktop and mobile); hidden when already on `/`.

## 4. Remaining light-theme contrast fixes

Continuation of the earlier-merged contrast pass — same root cause (hardcoded dark-navy background paired with theme-aware text):
- `public/css/styles.css` — `.quat-content` (Number Systems "Brain Teaser")
- `src/features/coal/data/CoalDiagrams.jsx` — RAID 0/1/5 disk backdrops + RISC instruction-block backdrop (SVG `fill`)
- `src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/EncoderPage.jsx` — "Binary-Index Trick" example box
- `src/features/dld-theory/combinational-circuits/encoder-decoder/encoder/components/EncoderSimulator.jsx` — encoding-result box (also surfaces the pre-existing "No inputs active" placeholder text, which was present but invisible)
- `src/index.css` / `.../encoder-decoder/shared/theme.js` — added `--indigo-accent-text` theme variable; `COLORS.indigoLight` now resolves via it, fixing low-contrast text on the "Play Animation" button and selected encoder-type button in light mode (dark mode unchanged)

---

## Testing notes

- Visit the first page of every DLD part and every COAL part — confirm "Previous part" appears and points correctly.
- From a part's last page, confirm "Continue to [next part]" still works.
- On a tracked topic page: scroll to bottom, click "Next" — confirm no auto-mark-as-read until you actually scroll.
- Confirm sidebar navigation still marks-as-read correctly at 90% scroll.
- Confirm logo no longer navigates; "Home" appears on `/problems`, `/boolforge`, `/kmapgenerator`, and COAL pages, hidden on `/`.
- Toggle light/dark theme on Number Systems, COAL RAID/CISC diagrams, and the Encoder page — confirm no dark/invisible boxes in light mode, dark mode unchanged.

## 👥 Reviewer Notes
Mention reviewers: @QuantumLogicsLabs @team-member

## 🔗 Vercel Preview
[Deployment Link](https://digital-logics-studio-seven.vercel.app/profile)
